### PR TITLE
Install fewer packages for texlive

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,16 +12,8 @@ runs:
       shell: bash
       run: |
         if [ ${{ inputs.use-latex }} == 'true' ]; then
-          packages=(
-            texlive-latex-base
-            texlive-latex-recommended
-            texlive-latex-extra
-            texlive-extra-utils
-            texlive-fonts-recommended
-            texlive-fonts-extra
-          )
           sudo apt-get update
-          sudo apt-get install "${packages[@]}"
+          sudo apt-get install --no-install-recommends texlive-latex-base texlive-latex-recommended
         fi
 
     - name: "Compile documentation"


### PR DESCRIPTION
Before: installs 136 packages, downloads 688 MB of archives, 1959 MB of additional disk space will be used

After: installs 14 packages, downloads 51 MB of archives, 168 MB of additional disk space will be used

Seems to work fine with all packages I tried it with so far. If any run into problems, we can either add back packages here, or else just modify the CI setup of the affected GAP packages to install more of texlive.

BTW by far the biggest chunk was `texlive-latex-recommended` which contributes like 500 MB downloads / 1422 MB disk space