### PR TITLE
Add functionality to check the constructed documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This GitHub action runs compiles the manual of a GAP package.
 
 The action `build-pkg-docs` has to be called by the workflow of a GAP
 package `gap-package`.
-By default it compiles the manual of a GAP package.
+By default it compiles the manual of a GAP package, and fails if any warnings
+are generated during this process.
 
 Its behaviour can be customized via the inputs below.
 
@@ -17,6 +18,10 @@ All of the following inputs are optional.
 - use-latex:
   - if `true`, then install and use latex
   - default: `false`
+- warnings-as-errors:
+  - if `true` then any errors produced whilst building the documentation will be
+    treated as errors
+  - default: `true`
 
 ### Examples
 

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,10 @@
-name: 'Compile GAP package documentation'
-description: 'Compile documentation with or without latex'
+name: "Compile GAP package documentation"
+description: "Compile documentation with or without latex"
 inputs:
   use-latex:
-    description: 'if true, then install and use latex'
+    description: "if true, then install and use latex"
     required: false
-    default: 'false'
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -31,7 +31,7 @@ runs:
         if [ -f "makedoc.g" ]; then
           $HOME/gap/gap -l "/tmp/gaproot;" --quitonbreak makedoc.g -c "QUIT;"
         elif [ -x "doc/make_doc" ]; then
-          # If the package is called <pkg_name>, then the <doc/make_doc> script
+          # If the package is called <pkg_name>, then the <doc/make_doc> script
           # most likely assumes that it has been called from the within the
           # <pkg_name>/doc folder, and that the directory hierarchy is
           # <gaproot>/pkg/<pkg_name>/doc/make_doc, and relies on this to access

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
         # (we already did that in build_pkg.sh, but we do it again here,
         # to allow the occasional instance where a package wants to also
         # run the tests of others packages, by invoking this script multiple
-        # times in different directories)``
+        # times in different directories)
         mkdir -p /tmp/gaproot/pkg/
         ln -f -s $PWD /tmp/gaproot/pkg/
     - name: "Compile documentation"

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ runs:
 
         Read("PackageInfo.g");
         doc_infos := GAPInfo.PackageInfoCurrent.PackageDoc;
-        filenames := ["HTMLStart", "PDFFile", "SixFile"];
+        filenames := [ "HTMLStart", "SixFile" ${{ inputs.use-latex == 'true' && ', "PDFFile"' || ''  }}];
 
         if IsRecord(doc_infos) then
           doc_infos := [doc_infos];

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "if true, then install and use latex"
     required: false
     default: "false"
+  warnings-as-errors:
+    description: "If set to true then any errors produced whilst building the documentation will be treated as errors"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -30,7 +34,7 @@ runs:
       shell: bash
       run: |
         if [ -f "makedoc.g" ]; then
-          $HOME/gap/gap -l "/tmp/gaproot;" --quitonbreak makedoc.g -c "QUIT;"
+          $HOME/gap/gap -l "/tmp/gaproot;" --quitonbreak makedoc.g -c "QUIT;" 2>&1 | tee output.log
         elif [ -x "doc/make_doc" ]; then
           # If the package is called <pkg_name>, then the <doc/make_doc> script
           # most likely assumes that it has been called from the within the
@@ -40,7 +44,7 @@ runs:
           # So we create symlinks to some potentially-useful GAP directories.
           [ -d ../../doc ] && echo "../../doc exists" || ln -s $HOME/gap/doc ../../doc
           [ -d ../../etc ] && echo "../../etc exists" || ln -s $HOME/gap/etc ../../etc
-          cd doc && ./make_doc
+          cd doc && ./make_doc  2>&1 | tee output.log
         elif [ -f "doc/make_doc" ]; then
           echo "doc/make_doc exists but is not executable!"
           exit 1
@@ -50,6 +54,15 @@ runs:
         fi
       env:
         SOURCE_DATE_EPOCH: 0 # prevent time stamps in generated PDF
+    - name: "Check for warnings"
+      if: ${{ inputs.warnings-as-errors == 'true' }}
+      shell: bash
+      run: |
+        grep -i -A2 warning output.log
+        if [ $? -eq 0 ]; then
+          echo "Warnings were found when building the documentation!"
+          exit 1
+        fi
     - name: "Check documentation is compiled"
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -5,18 +5,17 @@ inputs:
     description: "if true, then install and use latex"
     required: false
     default: "false"
+
 runs:
   using: "composite"
   steps:
     - name: "Install TeX Live"
+      if: ${{ inputs.use-latex == 'true' }}
       shell: bash
       run: |
-        if [ ${{ inputs.use-latex }} == 'true' ]; then
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
-        fi
-
-    - name: "Compile documentation"
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
+    - name: "Setup GAP root"
       shell: bash
       run: |
         # set up a custom GAP root containing only this package, so that
@@ -24,10 +23,12 @@ runs:
         # (we already did that in build_pkg.sh, but we do it again here,
         # to allow the occasional instance where a package wants to also
         # run the tests of others packages, by invoking this script multiple
-        # times in different directories)
+        # times in different directories)``
         mkdir -p /tmp/gaproot/pkg/
         ln -f -s $PWD /tmp/gaproot/pkg/
-
+    - name: "Compile documentation"
+      shell: bash
+      run: |
         if [ -f "makedoc.g" ]; then
           $HOME/gap/gap -l "/tmp/gaproot;" --quitonbreak makedoc.g -c "QUIT;"
         elif [ -x "doc/make_doc" ]; then
@@ -49,3 +50,34 @@ runs:
         fi
       env:
         SOURCE_DATE_EPOCH: 0 # prevent time stamps in generated PDF
+    - name: "Check documentation is compiled"
+      shell: bash
+      run: |
+        cat > __DOC_CHECKER__.g <<EOF
+
+        Read("PackageInfo.g");
+        doc_infos := GAPInfo.PackageInfoCurrent.PackageDoc;
+        filenames := ["HTMLStart", "PDFFile", "SixFile"];
+
+        if IsRecord(doc_infos) then
+          doc_infos := [doc_infos];
+        fi;
+
+        for doc_info in doc_infos do
+          for filename in filenames do
+            if not IsExistingFile( doc_info.(filename) ) then
+              Error(
+                Concatenation(
+                  "The documentation has supposedly been built, but the file ",
+                  doc_info.(filename),
+                  " specified in PackageDoc.",
+                  filename,
+                  " does not exist."
+                )
+              );
+            fi;
+          od;
+        od;
+
+        EOF
+        $HOME/gap/gap -l "/tmp/gaproot;" --quitonbreak __DOC_CHECKER__.g -c "QUIT;"

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,14 @@ runs:
         # times in different directories)
         mkdir -p /tmp/gaproot/pkg/
         ln -f -s $PWD /tmp/gaproot/pkg/
+    - name: "Check for GAP manual"
+      shell: bash
+      run: |
+        cd $HOME/gap/doc/ref
+        if [ ! -f manual.six ]; then
+          cd $HOME/gap
+          make html
+        fi
     - name: "Compile documentation"
       shell: bash
       run: |
@@ -52,6 +60,7 @@ runs:
           echo "no makedoc.g file or doc/make_doc script found!"
           exit 1
         fi
+        set +o pipefail
       env:
         SOURCE_DATE_EPOCH: 0 # prevent time stamps in generated PDF
     - name: "Check for warnings"

--- a/action.yml
+++ b/action.yml
@@ -60,15 +60,13 @@ runs:
           echo "no makedoc.g file or doc/make_doc script found!"
           exit 1
         fi
-        set +o pipefail
       env:
         SOURCE_DATE_EPOCH: 0 # prevent time stamps in generated PDF
     - name: "Check for warnings"
       if: ${{ inputs.warnings-as-errors == 'true' }}
       shell: bash
       run: |
-        grep -i -A2 warning output.log
-        if [ $? -eq 0 ]; then
+        if grep -i -A2 warning output.log; then
           echo "Warnings were found when building the documentation!"
           exit 1
         fi


### PR DESCRIPTION
This PR:
- [X] checks that the files specified in `PackageDoc` are generated; and
- [X] adds an option to treat warnings as errors (true by default).

This is tested [here](https://github.com/Joseph-Edwards/example/actions/workflows/test-doc.yml), and the docs pass and fail as expected.