### PR TITLE
Ignore errors when building GAP's manual.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ runs:
         cd $GAPROOT/doc/ref
         if [ ! -f manual.six ]; then
           cd $GAPROOT
-          make html
+          make html || :
         fi
     - name: "Compile documentation"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,14 @@ runs:
         if [ ! -f manual.six ]; then
           cd $GAPROOT
           make html || :
+          # build a HTML version of the GAP reference manual to allow subsequent 
+          # steps to pass when building a package manual that contains refs to
+          # the GAP reference manual.
+          # There is a caveat, though: building the GAP reference manual in turn
+          # can fail if it contains undefined references; this can happen because
+          # the GAP manual contains references to several packages and we don't
+          # install a full package distribution when running tests.
+          # See also <https://github.com/gap-actions/build-pkg-docs/issues/22>.
         fi
     - name: "Compile documentation"
       shell: bash


### PR DESCRIPTION
Closes https://github.com/gap-actions/build-pkg-docs/issues/22.

I don't think this is optimal, but it does more good than harm, I think. This prevents the action from failing if GAP's manuals are created with unresolved references, which should be fine - we only need GAP's manual to prevent unresolved references in the package's manual.

A possible problem is that make html could have failed completely, instead of just have unresolved references. We could check for the actual presence of the GAP manual a second time after make html to ensure this is not the case, but I'm not sure this is worth the effort...

(This is just #24, but I probably messed up resolving the conflicts through GitHub's website and it auto-closed the PR :upside_down_face: - sorry)