### PR TITLE
Use ActionTestDocPackages for testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,13 +17,16 @@ jobs:
         use-latex:
           - true
           - false
+        package:
+          - gap-actions/ActionTestGAPDocPackage
+          - gap-actions/ActionTestOldDocPackage
 
     steps:
       # the order of the checkout actions is important because all contents of
       # the target folder of the checkout action is removed
       - uses: actions/checkout@v5
         with:
-          repository: gap-packages/example
+          repository: ${{ matrix.package }}
       - uses: actions/checkout@v5
         with:
           path: this-action/


### PR DESCRIPTION
Seems like this is what those packages were created for, after all.

I'm not sure what to do about the failure of the old doc system together with `use-latex: false`. Do we expect actual `make_doc` files to handle this themselves (and hence we should update ActionTestOldDocPackage), or should we just exclude this combination?