### PR TITLE
Install Ubuntu package "tth" for use by make_docs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,11 +13,15 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: "Install tth (for old-style documentation)"
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends tth
     - name: "Install TeX Live"
       if: ${{ inputs.use-latex == 'true' }}
       shell: bash
       run: |
-        sudo apt-get update
         sudo apt-get install --no-install-recommends texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
     - name: "Check for GAP manual"
       shell: bash


### PR DESCRIPTION
I've seen this in package CI logs several times now:
```
Use of uninitialized value $whichtth in scalar chomp at ../../../etc/convert.pl line 2076.
Use of uninitialized value $whichtth in pattern match (m//) at ../../../etc/convert.pl line 2077.
Use of uninitialized value $whichtth in concatenation (.) or string at ../../../etc/convert.pl line 2078.
!! tth: not in path.
```