### PR TITLE
Also remove `.dvi` files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -135,4 +135,4 @@ runs:
     - name: "Remove auxiliary files"
       shell: bash
       run: |
-        find doc \( -name '*.aux' -o -name '*.bbl' -o -name '*.blg' -o -name '*.brf' -o -name '*.idx' -o -name '*.ilg' -o -name '*.ind' -o -name '*.log' -o -name '*.out' -o -name '*.pnr' -o -name '*.toc' -o -name '*.tst' \) -exec rm -f {} +
+        find doc \( -name '*.aux' -o -name '*.bbl' -o -name '*.blg' -o -name '*.brf' -o -name '*.dvi' -o -name '*.idx' -o -name '*.ilg' -o -name '*.ind' -o -name '*.log' -o -name '*.out' -o -name '*.pnr' -o -name '*.toc' -o -name '*.tst' \) -exec rm -f {} +


### PR DESCRIPTION
These are sometimes created when building a manual (e.g. for packages with an old `make_doc` script). Currently, these files actually end up in the release archives of these packages... and this messes with https://github.com/gap-actions/release-pkg/pull/54.