### PR TITLE
Also install `texlive-bibtex-extra` (e.g. to support the `alphaurl` bibstyle)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
       if: ${{ inputs.use-latex == 'true' }}
       shell: bash
       run: |
-        sudo apt-get install --no-install-recommends texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
+        sudo apt-get install --no-install-recommends texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-bibtex-extra
 
     - name: "Check for GAP manual"
       shell: bash


### PR DESCRIPTION
With the merge of https://github.com/gap-packages/AutoDoc/pull/359, AutoDoc supports alternative bibstyles like `alphaurl`. But creating a pdf with this bibstyle won't work unless `alphaurl.bst` is present. Annoyingly, it just causes `Citation ... on page ... undefined on input line ...` errors, instead of reporting a missing file.

Installing `texlive-bibtex-extra` fixes this.